### PR TITLE
Proper calculation of prflux and adjusting 'dv'

### DIFF
--- a/UWLCM_plotters/include/Plotter2d.hpp
+++ b/UWLCM_plotters/include/Plotter2d.hpp
@@ -179,7 +179,7 @@ class Plotter_t<2> : public PlotterCommon
     this->map["y"] = 1;
     this->map["z"] = n[1]-1;
     tmp.resize(n[0], n[1]);
-    dv.resize(n[0], n[1]);
+    dv.resize(n[0]-1, n[1]-1);
     k_i.resize(n[0]-1);
     tmp_int_hrzntl_slice.resize(n[0]-1);
     tmp_float_hrzntl_slice.resize(n[0]-1);
@@ -195,9 +195,11 @@ class Plotter_t<2> : public PlotterCommon
     this->DomainVol = this->map["dx"] * this->map["dz"] * this->map["x"] * this->map["z"];
 
     dv = this->CellVol;
-    // edge cells are smaller
+    // edge cells are 0.5*CellVol and corners are 0.25*CellVol
     dv(blitz::Range(0,0),blitz::Range::all()) /= 2.;
     dv(blitz::Range::all(),blitz::Range(0,0)) /= 2.;
+    dv(blitz::Range::all(),blitz::Range(dv.cols() - 1, dv.cols() - 1)) /= 2.;
+    dv(blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all()) /= 2.;
 
     // other dataset are of the size x*z, resize tmp
     tmp.resize(n[0]-1, n[1]-1);

--- a/UWLCM_plotters/include/Plotter2d.hpp
+++ b/UWLCM_plotters/include/Plotter2d.hpp
@@ -198,8 +198,8 @@ class Plotter_t<2> : public PlotterCommon
     // edge cells are 0.5*CellVol and corners are 0.25*CellVol
     dv(blitz::Range(0,0),blitz::Range::all()) /= 2.;
     dv(blitz::Range::all(),blitz::Range(0,0)) /= 2.;
-    dv(blitz::Range::all(),blitz::Range(dv.cols() - 1, dv.cols() - 1)) /= 2.;
-    dv(blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all()) /= 2.;
+    dv(blitz::Range::all(),blitz::Range(n[1] - 2, n[1] - 2)) /= 2.;
+    dv(blitz::Range(n[0] - 2, n[0] - 2), blitz::Range::all()) /= 2.;
 
     // other dataset are of the size x*z, resize tmp
     tmp.resize(n[0]-1, n[1]-1);

--- a/UWLCM_plotters/include/Plotter3d.hpp
+++ b/UWLCM_plotters/include/Plotter3d.hpp
@@ -209,7 +209,7 @@ class Plotter_t<3> : public PlotterCommon
     this->map["y"] = n[1]-1;
     this->map["z"] = n[2]-1;
     tmp.resize(n[0], n[1], n[2]);
-    dv.resize(n[0], n[1], n[2]);
+    dv.resize(n[0]-1, n[1]-1, n[2]-1);
     k_i.resize(n[0]-1, n[1]-1);
     tmp_int_hrzntl_slice.resize(n[0]-1, n[1]-1);
     tmp_float_hrzntl_slice.resize(n[0]-1, n[1]-1);
@@ -227,10 +227,13 @@ class Plotter_t<3> : public PlotterCommon
     this->DomainVol = this->map["dx"] * this->map["dy"] * this->map["dz"] * this->map["x"] * this->map["y"] * this->map["z"];
 
     dv = this->CellVol;
-    // edge cells are smaller
-    dv(blitz::Range(0,0),blitz::Range::all(),blitz::Range::all()) /= 2.;
-    dv(blitz::Range::all(),blitz::Range(0,0),blitz::Range::all()) /= 2.;
-    dv(blitz::Range::all(),blitz::Range::all(),blitz::Range(0,0)) /= 2.;
+    // edge cells are 0.5*CellVol and corners are 0.25*CellVol
+    dv(blitz::Range(0,0), blitz::Range::all(), blitz::Range::all()) /= 2.;
+    dv(blitz::Range::all(), blitz::Range(0,0), blitz::Range::all()) /= 2.;
+    dv(blitz::Range::all(), blitz::Range::all(), blitz::Range(0,0)) /= 2.;
+    dv(blitz::Range::all(), blitz::Range::all(), blitz::Range(dv.cols() - 1, dv.cols() - 1)) /= 2.;
+    dv(blitz::Range::all(), blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all()) /= 2.;
+    dv(blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all(), blitz::Range::all()) /= 2.;
 
     // other dataset are of the size x*z, resize tmp
     tmp.resize(n[0]-1, n[1]-1, n[2]-1);

--- a/UWLCM_plotters/include/Plotter3d.hpp
+++ b/UWLCM_plotters/include/Plotter3d.hpp
@@ -231,10 +231,10 @@ class Plotter_t<3> : public PlotterCommon
     dv(blitz::Range(0,0), blitz::Range::all(), blitz::Range::all()) /= 2.;
     dv(blitz::Range::all(), blitz::Range(0,0), blitz::Range::all()) /= 2.;
     dv(blitz::Range::all(), blitz::Range::all(), blitz::Range(0,0)) /= 2.;
-    dv(blitz::Range::all(), blitz::Range::all(), blitz::Range(dv.cols() - 1, dv.cols() - 1)) /= 2.;
-    dv(blitz::Range::all(), blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all()) /= 2.;
-    dv(blitz::Range(dv.rows() - 1, dv.rows() - 1), blitz::Range::all(), blitz::Range::all()) /= 2.;
-
+    dv(blitz::Range(n[0] - 2, n[0] - 2), blitz::Range::all(), blitz::Range::all()) /= 2.;
+    dv(blitz::Range::all(), blitz::Range(n[1] - 2, n[1] - 2), blitz::Range::all()) /= 2.;
+    dv(blitz::Range::all(), blitz::Range::all(), blitz::Range(n[2] - 2, n[2] - 2)) /= 2.;
+    
     // other dataset are of the size x*z, resize tmp
     tmp.resize(n[0]-1, n[1]-1, n[2]-1);
     tmp_srfc.resize(n[0]-1, n[1]-1, 1);

--- a/UWLCM_plotters/include/PlotterMicro.hpp
+++ b/UWLCM_plotters/include/PlotterMicro.hpp
@@ -108,8 +108,9 @@ class PlotterMicro_t : public Plotter_t<NDims>
     {
       res = this->h5load_timestep("precip_rate", at)
               *  4./3 * 3.14 * 1e3 // to get mass
-              / this->CellVol    // averaged over cell volume, TODO: make precip rate return specific moment? wouldnt need the dx and dy
+              / this->dv   // averaged over cell volume, TODO: make precip rate return specific moment? wouldnt need the dx and dy
               * L_evap;
+              //CellVol all having the same volume, this multiplication below include 0.5 * CellVol on the domain boredrs and 0.25 * CellVol on the domain corners
     }
     else if(this->micro == "blk_1m")
       try


### PR DESCRIPTION
Updated 
UWLCM_plotters/include/Plotter3d.hpp
UWLCM_plotters/include/Plotter2d.hpp
UWLCM_plotters/include/PlotterMicro.hpp

To proper calculation of prflux in vertical profiles. 'dv' updated to have shape of CellVol -1 at each dimension. 